### PR TITLE
feat: make API URL configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,24 @@ Express server with React frontend.
 ## Development
 
 1. Install dependencies: `npm install`.
-2. Start both servers: `npm run dev`.
+2. Create a `.env` file with the backend URL:
+
+   ```bash
+   REACT_APP_API_URL=http://localhost:5000
+   ```
+
+3. Start both servers: `npm run dev`.
    - React runs on [http://localhost:3000](http://localhost:3000).
-   - API requests are proxied to Express on [http://localhost:5000](http://localhost:5000).
+   - Express listens on [http://localhost:5000](http://localhost:5000).
 
 ## Production
 
-1. Build the React bundle: `npm run build`.
+1. Set `REACT_APP_API_URL` to the production backend before building, for example:
+
+   ```bash
+   REACT_APP_API_URL=https://api.example.com npm run build
+   ```
+
 2. Start the server: `npm start` (serves static files from `build/`).
 3. A `Procfile` is provided for platforms like Heroku and runs `npm run build && node server.js`.
 
@@ -42,6 +53,7 @@ Create a `.env` file or set variables in your host:
 ```bash
 PORT=5000
 NODE_ENV=production
+# REACT_APP_API_URL=http://localhost:5000
 # CLIENT_ID=your-client-id
 # CLIENT_SECRET=your-secret
 ```

--- a/package.json
+++ b/package.json
@@ -48,6 +48,5 @@
   "devDependencies": {
     "concurrently": "^8.2.2",
     "nodemon": "^3.1.10"
-  },
-  "proxy": "http://localhost:5000"
+  }
 }

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -2,10 +2,10 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 
 // Mock axios to avoid importing the ESM module during tests
-jest.mock('axios', () => ({
-  get: jest.fn(),
-  post: jest.fn(),
-}));
+jest.mock('axios', () => {
+  const instance = { get: jest.fn(), post: jest.fn() };
+  return { create: jest.fn(() => instance), ...instance };
+});
 
 beforeEach(() => {
   global.fetch = jest.fn(() =>

--- a/src/utils/spotifyAPI.js
+++ b/src/utils/spotifyAPI.js
@@ -1,5 +1,9 @@
 import axios from 'axios';
 
+const api = axios.create({
+  baseURL: process.env.REACT_APP_API_URL,
+});
+
 const unauthorized = { unauthorized: true };
 
 const handleUnauthorized = (error) => {
@@ -11,7 +15,7 @@ const handleUnauthorized = (error) => {
 
 export const getQueue = async () => {
   try {
-    const response = await axios.get('/api/queue');
+    const response = await api.get('/api/queue');
     return response.data;
   } catch (error) {
     try {
@@ -25,7 +29,7 @@ export const getQueue = async () => {
 
 export const searchTracks = async (query) => {
   try {
-    const response = await axios.get('/api/search', { params: { q: query } });
+    const response = await api.get('/api/search', { params: { q: query } });
     return response.data.tracks || response.data;
   } catch (error) {
     const result = handleUnauthorized(error);
@@ -39,7 +43,7 @@ export const searchTracks = async (query) => {
 
 export const addToQueue = async (trackUri) => {
   try {
-    await axios.post('/api/queue', { uri: trackUri });
+    await api.post('/api/queue', { uri: trackUri });
     return true;
   } catch (error) {
     const result = handleUnauthorized(error);


### PR DESCRIPTION
## Summary
- remove hard-coded CRA proxy config
- read API base URL from `REACT_APP_API_URL`
- document configuring backend URL for dev and production

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689607120cb48332b758dbde87c81640