### PR TITLE
chore: add cross-env to dev script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.9.0",
         "crypto-js": "^4.2.0",
-        "express": "^4.21.2",
+        "express": "^4.19.2",
         "passport-windowsauth": "^3.0.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -23,6 +23,7 @@
       },
       "devDependencies": {
         "concurrently": "^8.2.2",
+        "cross-env": "^10.0.0",
         "nodemon": "^3.1.10"
       }
     },
@@ -2207,6 +2208,13 @@
       "peerDependencies": {
         "postcss-selector-parser": "^6.0.10"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.7.0",
@@ -5659,6 +5667,24 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.0.0.tgz",
+      "integrity": "sha512-aU8qlEK/nHYtVuN4p7UQgAwVljzMg8hB4YK5ThRqD2l/ziSnryncPNn7bMLt5cFYsKVKBh8HqLqyCoTupEUu7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build": "react-scripts build",
     "server": "nodemon server.js",
     "client": "react-scripts start",
-    "dev": "concurrently \"PORT=5000 SERVER_PORT=5000 npm run server\" \"PORT=3000 npm run client\"",
+    "dev": "concurrently \"cross-env PORT=5000 SERVER_PORT=5000 npm run server\" \"cross-env PORT=3000 npm run client\"",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "heroku-postbuild": "npm run build"
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "concurrently": "^8.2.2",
-    "nodemon": "^3.1.10"
+    "nodemon": "^3.1.10",
+    "cross-env": "^10.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add cross-env as a dev dependency
- use cross-env in dev script so env vars work cross-platform

## Testing
- `npm install --package-lock-only`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68960b93f37c8332bb4c0037f7c030f2