### PR TITLE
docs: remove proxy reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Express server with React frontend.
 3. Start both servers: `npm run dev`.
    - React runs on [http://localhost:3000](http://localhost:3000).
    - Express listens on [http://localhost:5000](http://localhost:5000).
-   - If you need a different backend port, update both the port in the `dev` script and the `proxy` value in `package.json` so they stay in sync.
+   - If you need a different backend port, update both the port in the `dev` script and your `REACT_APP_API_URL` so they stay in sync.
 
 ## Production
 


### PR DESCRIPTION
## Summary
- fix development instructions by replacing proxy reference with REACT_APP_API_URL guidance

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68961171c908833295a9f1d2a0240a7d