### PR TITLE
Use dedicated endpoint for queue additions

### DIFF
--- a/src/utils/spotifyAPI.js
+++ b/src/utils/spotifyAPI.js
@@ -43,7 +43,7 @@ export const searchTracks = async (query) => {
 
 export const addToQueue = async (trackUri) => {
   try {
-    await api.post('/api/queue', { uri: trackUri });
+    await api.post('/api/add-to-queue', { uri: trackUri });
     return true;
   } catch (error) {
     const result = handleUnauthorized(error);


### PR DESCRIPTION
## Summary
- switch client queue addition requests to `/api/add-to-queue`

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_689632afe1788332940914635980ab02