### PR TITLE
Add /api/me endpoint

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -44,6 +44,14 @@ async function spotifyRequest(method, url, options = {}) {
   return axios({ method, url, ...options, headers });
 }
 
+app.get('/api/me', auth, (req, res) => {
+  try {
+    res.json(req.user);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to retrieve user' });
+  }
+});
+
 app.get('/api/search', auth, async (req, res) => {
   const q = req.query.q;
   if (!q) {


### PR DESCRIPTION
## Summary
- expose `/api/me` route to return authenticated user data
- safeguard route with basic error handling

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_689633a8d68c8332b0a7cffb5d1d758d