### PR TITLE
Handle network errors when fetching queue

### DIFF
--- a/src/components/QueueViewer.js
+++ b/src/components/QueueViewer.js
@@ -13,6 +13,8 @@ const QueueViewer = () => {
         const queueData = await getQueue();
         if (queueData && queueData.unauthorized) {
           setError('Session expired. Please reauthenticate with Windows.');
+        } else if (queueData && queueData.networkError) {
+          setError('Network error. Please check your connection and try again.');
         } else if (queueData) {
           setQueue(queueData);
         } else {

--- a/src/utils/spotifyAPI.js
+++ b/src/utils/spotifyAPI.js
@@ -5,6 +5,7 @@ const api = axios.create({
 });
 
 const unauthorized = { unauthorized: true };
+const networkError = { networkError: true };
 
 const handleUnauthorized = (error) => {
   if (error.response && (error.response.status === 401 || error.response.status === 403)) {
@@ -18,6 +19,10 @@ export const getQueue = async () => {
     const response = await api.get('/api/queue');
     return response.data;
   } catch (error) {
+    if (!error.response) {
+      console.error('Network error fetching queue:', error);
+      return networkError;
+    }
     try {
       return handleUnauthorized(error);
     } catch (err) {


### PR DESCRIPTION
## Summary
- detect Axios network failures in `getQueue` and return a distinct error object
- show a helpful message in `QueueViewer` when a network error occurs

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689634b7205c8332b9233e8e5511e571