### PR TITLE
Handle missing API URL with fallback to origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Express server with React frontend.
    REACT_APP_API_URL=http://localhost:5000
    ```
 
+   If `REACT_APP_API_URL` is not set, the frontend logs a warning and uses the current browser origin for API requests.
+
 3. Start both servers: `npm run dev`.
    - React runs on [http://localhost:3000](http://localhost:3000).
    - Express listens on [http://localhost:5000](http://localhost:5000).
@@ -58,6 +60,8 @@ NODE_ENV=production
 # CLIENT_ID=your-client-id
 # CLIENT_SECRET=your-secret
 ```
+
+If `REACT_APP_API_URL` is omitted, API calls fall back to `window.location.origin`.
 
 - `REACT_APP_REDIRECT_URI` – OAuth callback URL for the React app.
 

--- a/src/utils/spotifyAPI.js
+++ b/src/utils/spotifyAPI.js
@@ -1,7 +1,12 @@
 import axios from 'axios';
 
+const baseURL = process.env.REACT_APP_API_URL;
+if (!baseURL) {
+  console.warn('REACT_APP_API_URL is not set; falling back to current origin.');
+}
+
 const api = axios.create({
-  baseURL: process.env.REACT_APP_API_URL,
+  baseURL: baseURL || window.location.origin,
 });
 
 const unauthorized = { unauthorized: true };


### PR DESCRIPTION
## Summary
- warn when `REACT_APP_API_URL` is not set and default requests to `window.location.origin`
- document the fallback behavior and configuration expectations in `README`

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_689635f896f0833284cf4a5db34a94e9