### PR TITLE
Add CORS support with configurable client origin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.9.0",
+        "cors": "^2.8.5",
         "crypto-js": "^4.2.0",
         "express": "^4.21.2",
         "passport-windowsauth": "^3.0.1",
@@ -5653,6 +5654,19 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -8,13 +8,14 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.9.0",
+    "cors": "^2.8.5",
     "crypto-js": "^4.2.0",
     "express": "^4.21.2",
+    "passport-windowsauth": "^3.0.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-scripts": "^5.0.1",
-    "web-vitals": "^2.1.4",
-    "passport-windowsauth": "^3.0.1"
+    "web-vitals": "^2.1.4"
   },
   "scripts": {
     "start": "node server/index.js",
@@ -46,7 +47,7 @@
   },
   "devDependencies": {
     "concurrently": "^8.2.2",
-    "nodemon": "^3.1.10",
-    "cross-env": "^10.0.0"
+    "cross-env": "^10.0.0",
+    "nodemon": "^3.1.10"
   }
 }

--- a/server/index.js
+++ b/server/index.js
@@ -3,9 +3,12 @@ const passport = require('passport');
 const WindowsStrategy = require('passport-windowsauth');
 const axios = require('axios');
 const path = require('path');
+const cors = require('cors');
 
 const app = express();
 app.use(express.json());
+const clientOrigin = process.env.CLIENT_ORIGIN || 'http://localhost:3000';
+app.use(cors({ origin: clientOrigin, credentials: true }));
 
 // Configure Windows authentication using passport-windowsauth
 passport.use(new WindowsStrategy({


### PR DESCRIPTION
## Summary
- install `cors` package
- enable CORS in server with configurable `CLIENT_ORIGIN`

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68963a0827cc8332b9507f8d69257d52