### PR TITLE
feat: send credentials with axios requests

### DIFF
--- a/src/utils/spotifyAPI.js
+++ b/src/utils/spotifyAPI.js
@@ -7,6 +7,7 @@ if (!baseURL) {
 
 const api = axios.create({
   baseURL: baseURL || window.location.origin,
+  withCredentials: true,
 });
 
 const unauthorized = { unauthorized: true };


### PR DESCRIPTION
## Summary
- allow axios to send cookies to the backend for Windows authentication

## Testing
- `npm test -- --watchAll=false`
- `curl -i --negotiate -u : http://localhost:3001/api/me` (401 Unauthorized)


------
https://chatgpt.com/codex/tasks/task_e_68963b1372f483328f5548d4649045e9