### PR TITLE
Use environment variables for NTLM configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This project contains a React frontend and an Express server for an office jukeb
 
 The Express app lives in `server/index.js` and is protected with Windows authentication via [`express-ntlm`](https://www.npmjs.com/package/express-ntlm). The middleware authenticates users against Active Directory and exposes the authenticated profile on `req.ntlm` for all API requests.
 
+Set `NTLM_DOMAIN` to your Active Directory domain and `NTLM_DC` to the LDAP URL of a domain controller.
+
 ### Spotify credentials
 
 The server interacts with the Spotify Web API using a shared office account. Configure the following environment variables before starting the server:
@@ -59,6 +61,8 @@ NODE_ENV=production
 # REACT_APP_API_URL=http://localhost:5000
 # CLIENT_ID=your-client-id
 # CLIENT_SECRET=your-secret
+# NTLM_DOMAIN=YOUR_DOMAIN
+# NTLM_DC=ldap://dc.yourdomain.local
 ```
 
 If `REACT_APP_API_URL` is omitted, API calls fall back to `window.location.origin`.

--- a/server/index.js
+++ b/server/index.js
@@ -11,8 +11,8 @@ app.use(cors({ origin: clientOrigin, credentials: true }));
 
 app.use(ntlm({
   debug: console.log,
-  domain: 'YOUR_DOMAIN',
-  domaincontroller: 'ldap://dc.yourdomain.local'
+  domain: process.env.NTLM_DOMAIN,
+  domaincontroller: process.env.NTLM_DC
 }));
 
 const ensureAuthenticated = (req, res, next) => {


### PR DESCRIPTION
## Summary
- Replace hard-coded NTLM domain and controller with `NTLM_DOMAIN` and `NTLM_DC` environment variables.
- Document `NTLM_DOMAIN` and `NTLM_DC` in README so deployments can configure Active Directory settings.

## Testing
- `CI=1 npm test`

------
https://chatgpt.com/codex/tasks/task_e_689666496f108332b538ad7ddef29c8a