### PR TITLE
Log detailed Spotify queue errors

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -47,7 +47,12 @@ async function getAccessToken() {
 async function spotifyRequest(method, url, options = {}) {
   const token = await getAccessToken();
   const headers = { ...options.headers, Authorization: `Bearer ${token}` };
-  return axios({ method, url, ...options, headers });
+  try {
+    return await axios({ method, url, ...options, headers });
+  } catch (err) {
+    console.error('Spotify API request failed:', err.response?.status, err.response?.data);
+    throw err;
+  }
 }
 
 app.get('/api/me', ensureAuthenticated, (req, res) => {
@@ -79,6 +84,7 @@ app.get('/api/queue', ensureAuthenticated, async (req, res) => {
     const response = await spotifyRequest('get', 'https://api.spotify.com/v1/me/player/queue');
     res.json(response.data);
   } catch (err) {
+    console.error('Error fetching Spotify queue:', err.response?.status, err.response?.data);
     res.status(500).json({ error: 'Spotify queue fetch failed' });
   }
 });

--- a/src/utils/spotifyAPI.js
+++ b/src/utils/spotifyAPI.js
@@ -26,13 +26,13 @@ export const getQueue = async () => {
     return response.data;
   } catch (error) {
     if (!error.response) {
-      console.error('Network error fetching queue:', error);
+      console.error('Network error fetching queue:', error, error.response?.data);
       return networkError;
     }
     try {
       return handleUnauthorized(error);
     } catch (err) {
-      console.error('Error fetching queue:', err);
+      console.error('Error fetching queue:', err, err.response?.data);
       return null;
     }
   }


### PR DESCRIPTION
## Summary
- Log Spotify API response status and data in backend `spotifyRequest` helper and `/api/queue` endpoint
- Surface response data when frontend `getQueue` encounters errors

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6896676a41bc8332a79284f8661d6cce